### PR TITLE
Removed `workflow` gem and Refactored functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-v0.2.1 - 25 Aug 2015
+v0.3.0 - 28 Aug 2015
 ---
 Added created_at and updated_at to process and task as attributes.
 Improved serialization visitor to include an optional converter block for deserialization of attribute values.
 Corrections to lazy loader logic and speed improvements.
 Removed JobWorker as it's no longer necessary.
-Improvements to instrumentation
+Improvements to instrumentation.
+Removed workflow gem, and refactored process and task to implement the basics instead.
+Several bug fixes.
 
 v0.2.0 - 31 Jul 2015
 ---

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in Taskinator.gemspec
 gemspec
 
-# add as a git gem dependency until version 1.3.0 is released to RubyGems.
-gem 'workflow', :github => 'virtualstaticvoid/workflow', :branch => :master
-
 # queues
 gem 'sidekiq'         , '>= 3.5.0', :github => "mperham/sidekiq"
 gem 'rspec-sidekiq'   , '>= 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,17 +9,10 @@ GIT
       redis (~> 3.2, >= 3.2.1)
       redis-namespace (~> 1.5, >= 1.5.2)
 
-GIT
-  remote: git://github.com/virtualstaticvoid/workflow.git
-  revision: 403a9e44bf49f4d154156d5701e3d67b115ed6da
-  branch: master
-  specs:
-    workflow (1.3.0)
-
 PATH
   remote: .
   specs:
-    taskinator (0.2.1)
+    taskinator (0.3.0)
       connection_pool (>= 2.2.0)
       json (>= 1.8.2)
       redis (>= 3.2.1)
@@ -194,4 +187,3 @@ DEPENDENCIES
   rspec-sidekiq (>= 2.1.0)
   sidekiq (>= 3.5.0)!
   taskinator!
-  workflow!

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ To monitor the state of the processes, use the `Taskinator::Api::Processes` clas
 processes = Taskinator::Api::Processes.new
 processes.each do |process|
   # => output the unique process identifier and current state
-  puts [:process, process.uuid, process.current_state.name]
+  puts [:process, process.uuid, process.current_state]
 end
 ```
 
@@ -613,11 +613,14 @@ The following instrumentation events are issued:
 | `taskinator.process.created`       | After a root process gets created                         |
 | `taskinator.process.saved`         | After a root process has been persisted to Redis          |
 | `taskinator.process.enqueued`      | After a process or subprocess is enqueued for processing  |
+| `taskinator.process.processing`    | When a process or subprocess is processing                |
+| `taskinator.process.paused`        | When a process or subprocess is paused                    |
+| `taskinator.process.resumed`       | When a process or subprocess is resumed                   |
 | `taskinator.process.completed`     | After a process or subprocess has completed processing    |
 | `taskinator.process.cancelled`     | After a process or subprocess has been cancelled          |
 | `taskinator.process.failed`        | After a process or subprocess has failed                  |
 | `taskinator.task.enqueued`         | After a task has been enqueued                            |
-| `taskinator.task.executed`         | After a task has executed                                 |
+| `taskinator.task.processing`       | When a task is processing                                 |
 | `taskinator.task.completed`        | After a task has completed                                |
 | `taskinator.task.cancelled`        | After a task has been cancelled                           |
 | `taskinator.task.failed`           | After a task has failed                                   |

--- a/lib/taskinator.rb
+++ b/lib/taskinator.rb
@@ -1,7 +1,6 @@
 require 'json'
 require 'yaml'
 require 'securerandom'
-require 'workflow'
 
 require 'taskinator/version'
 
@@ -10,6 +9,8 @@ require 'taskinator/redis_connection'
 require 'taskinator/logger'
 
 require 'taskinator/definition'
+
+require 'taskinator/workflow'
 
 require 'taskinator/visitor'
 require 'taskinator/persistence'

--- a/lib/taskinator/instrumentation.rb
+++ b/lib/taskinator/instrumentation.rb
@@ -13,8 +13,16 @@ module Taskinator
       payload_for(:enqueued, additional)
     end
 
-    def started_payload(additional={})
+    def processing_payload(additional={})
       payload_for(:processing, additional)
+    end
+
+    def paused_payload(additional={})
+      payload_for(:paused, additional)
+    end
+
+    def resumed_payload(additional={})
+      payload_for(:resumed, additional)
     end
 
     def completed_payload(additional={})
@@ -25,8 +33,8 @@ module Taskinator
       payload_for(:cancelled, additional)
     end
 
-    def failed_payload(additional={})
-      payload_for(:failed, additional)
+    def failed_payload(exception, additional={})
+      payload_for(:failed, { :exception => exception.to_s, :backtrace => exception.backtrace }.merge(additional))
     end
 
     private
@@ -36,24 +44,32 @@ module Taskinator
       # need to cache here, since this method hits redis, so can't be part of multi statement following
       process_key = self.process_key
 
-      tasks_count, completed_count, cancelled_count, failed_count = Taskinator.redis do |conn|
-        conn.hmget process_key, :tasks_count, :completed, :cancelled, :failed
+      tasks_count, processing_count, completed_count, cancelled_count, failed_count = Taskinator.redis do |conn|
+        conn.hmget process_key,
+                   :tasks_count,
+                   :tasks_processing,
+                   :tasks_completed,
+                   :tasks_cancelled,
+                   :tasks_failed
       end
 
       tasks_count = tasks_count.to_f
 
-      return {
-        :type                  => self.class.name,
-        :process_uuid          => process_uuid,
-        :process_options       => process_options,
-        :uuid                  => uuid,
-        :options               => options,
-        :state                 => state,
-        :percentage_failed     => (tasks_count > 0) ? (failed_count.to_i    / tasks_count) * 100.0 : 0.0,
-        :percentage_cancelled  => (tasks_count > 0) ? (cancelled_count.to_i / tasks_count) * 100.0 : 0.0,
-        :percentage_completed  => (tasks_count > 0) ? (completed_count.to_i / tasks_count) * 100.0 : 0.0,
-        :instance              => self
-      }.merge(additional)
+      return OpenStruct.new(
+        {
+          :type                   => self.class,
+          :process_uuid           => process_uuid,
+          :process_options        => process_options,
+          :uuid                   => uuid,
+          :options                => options,
+          :state                  => state,
+          :percentage_failed      => (tasks_count > 0) ? (failed_count.to_i     / tasks_count) * 100.0 : 0.0,
+          :percentage_cancelled   => (tasks_count > 0) ? (cancelled_count.to_i  / tasks_count) * 100.0 : 0.0,
+          :percentage_processing  => (tasks_count > 0) ? (processing_count.to_i / tasks_count) * 100.0 : 0.0,
+          :percentage_completed   => (tasks_count > 0) ? (completed_count.to_i  / tasks_count) * 100.0 : 0.0,
+          :instance               => self
+        }.merge(additional)
+      ).freeze
 
     end
 

--- a/lib/taskinator/persistence.rb
+++ b/lib/taskinator/persistence.rb
@@ -35,17 +35,6 @@ module Taskinator
         "taskinator:#{base_key}:#{uuid}"
       end
 
-      # retrieves the workflow state for the given identifier
-      # this prevents to need to load the entire object when
-      # querying for the status of an instance
-      def state_for(uuid)
-        key = key_for(uuid)
-        state = Taskinator.redis do |conn|
-          conn.hget(key, :state) || 'initial'
-        end
-        state.to_sym
-      end
-
       # fetches the instance for given identifier
       # optionally, provide a hash to use for the instance cache
       # this argument is defaulted, so top level callers don't
@@ -68,10 +57,11 @@ module Taskinator
             visitor = RedisSerializationVisitor.new(conn, self).visit
             conn.hmset(
               Taskinator::Process.key_for(uuid),
-              :tasks_count,     visitor.task_count,
-              :tasks_failed,    0,
-              :tasks_completed, 0,
-              :tasks_cancelled, 0,
+              :tasks_count,      visitor.task_count,
+              :tasks_failed,     0,
+              :tasks_processing, 0,
+              :tasks_completed,  0,
+              :tasks_cancelled,  0,
             )
             true
           end
@@ -95,39 +85,36 @@ module Taskinator
         @process_key ||= Taskinator::Process.key_for(process_uuid)
       end
 
-      # cache of the current state (eventually consistent!)
-      attr_reader :state
-
       # retrieves the workflow state
       # this method is called from the workflow gem
       def load_workflow_state
         state = Taskinator.redis do |conn|
-          conn.hget(self.key, :state)
+          conn.hget(self.key, :state) || 'initial'
         end
-        @state = (state || 'initial').to_sym
+        state.to_sym
       end
 
       # persists the workflow state
       # this method is called from the workflow gem
       def persist_workflow_state(new_state)
-        time_now = Time.now.utc
+        @updated_at = Time.now.utc
         Taskinator.redis do |conn|
           process_key = self.process_key
           conn.multi do
             conn.hmset(
               self.key,
               :state, new_state,
-              :updated_at, time_now
+              :updated_at, @updated_at
             )
 
             # also update the "root" process
             conn.hset(
               process_key,
-              :updated_at, time_now
+              :updated_at, @updated_at
             )
           end
         end
-        @state = new_state
+        new_state
       end
 
       # persists the error information
@@ -152,7 +139,7 @@ module Taskinator
           error_type, error_message, error_backtrace =
             conn.hmget(self.key, :error_type, :error_message, :error_backtrace)
 
-          [error_type, error_message, JSON.parse(error_backtrace)]
+          [error_type, error_message, JSON.parse(error_backtrace || '[]')]
         end
       end
 
@@ -168,12 +155,13 @@ module Taskinator
       %w(
         failed
         cancelled
+        processing
         completed
       ).each do |status|
 
         define_method "count_#{status}" do
           count = Taskinator.redis do |conn|
-            conn.hget self.process_key, status
+            conn.hget self.process_key, "tasks_#{status}"
           end
           count.to_i
         end
@@ -182,7 +170,7 @@ module Taskinator
           Taskinator.redis do |conn|
             process_key = self.process_key
             conn.multi do
-              conn.hincrby process_key, status, 1
+              conn.hincrby process_key, "tasks_#{status}", 1
               conn.hset process_key, :updated_at, Time.now.utc
             end
           end
@@ -270,6 +258,10 @@ module Taskinator
       end
 
       def visit_attribute_time(attribute)
+        visit_attribute(attribute)
+      end
+
+      def visit_attribute_enum(attribute, type)
         visit_attribute(attribute)
       end
 
@@ -388,6 +380,15 @@ module Taskinator
       def visit_attribute_time(attribute)
         visit_attribute(attribute) do |value|
           Time.parse(value)
+        end
+      end
+
+      # NB: assumes the enum type's members have integer values!
+      # NB: assumes the type defines a "Default" member
+      def visit_attribute_enum(attribute, type)
+        visit_attribute(attribute) do |value|
+          const_value = type.constants.select {|c| type.const_get(c) == value.to_i }.first
+          const_value ? type.const_get(const_value) : type::Default
         end
       end
 

--- a/lib/taskinator/persistence.rb
+++ b/lib/taskinator/persistence.rb
@@ -384,11 +384,12 @@ module Taskinator
       end
 
       # NB: assumes the enum type's members have integer values!
-      # NB: assumes the type defines a "Default" member
       def visit_attribute_enum(attribute, type)
         visit_attribute(attribute) do |value|
           const_value = type.constants.select {|c| type.const_get(c) == value.to_i }.first
-          const_value ? type.const_get(const_value) : type::Default
+          const_value ?
+            type.const_get(const_value) :
+            (defined?(type::Default) ? type::Default : nil)
         end
       end
 

--- a/lib/taskinator/version.rb
+++ b/lib/taskinator/version.rb
@@ -1,3 +1,3 @@
 module Taskinator
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/lib/taskinator/visitor.rb
+++ b/lib/taskinator/visitor.rb
@@ -13,6 +13,9 @@ module Taskinator
       def visit_attribute_time(attribute)
       end
 
+      def visit_attribute_enum(attribute, type)
+      end
+
       def visit_process_reference(attribute)
       end
 

--- a/lib/taskinator/workflow.rb
+++ b/lib/taskinator/workflow.rb
@@ -1,0 +1,36 @@
+module Taskinator
+  module Workflow
+
+    def current_state
+      @current_state ||= load_workflow_state
+    end
+
+    def current_state=(new_state)
+      @current_state = persist_workflow_state(new_state)
+    end
+
+    def transition(new_state)
+      self.current_state = new_state
+      yield if block_given?
+      current_state
+    end
+
+    %i(
+      initial
+      enqueued
+      processing
+      paused
+      resumed
+      completed
+      cancelled
+      failed
+    ).each do |state|
+
+      define_method :"#{state}?" do
+        @current_state == state
+      end
+
+    end
+
+  end
+end

--- a/spec/examples/process_examples.rb
+++ b/spec/examples/process_examples.rb
@@ -2,15 +2,12 @@ require 'spec_helper'
 
 shared_examples_for "a process" do |process_type|
 
-  # NOTE: definition and process must be defined by callee
+  # NOTE: definition and subject must be defined by callee
 
-  # let(:definition) {}
-  # let(:process) {}
-
-  it { expect(process.definition).to eq(definition)  }
-  it { expect(process.uuid).to_not be_nil }
-  it { expect(process.to_s).to match(/#{process.uuid}/) }
-  it { expect(process.options).to_not be_nil }
-  it { expect(process.tasks).to_not be_nil }
+  it { expect(subject.definition).to eq(definition)  }
+  it { expect(subject.uuid).to_not be_nil }
+  it { expect(subject.to_s).to match(/#{subject.uuid}/) }
+  it { expect(subject.options).to_not be_nil }
+  it { expect(subject.tasks).to_not be_nil }
 
 end

--- a/spec/examples/task_examples.rb
+++ b/spec/examples/task_examples.rb
@@ -2,14 +2,11 @@ require 'spec_helper'
 
 shared_examples_for "a task" do |task_type|
 
-  # NOTE: process and task must be defined by callee
+  # NOTE: process and subject must be defined by callee
 
-  # let(:process) {}
-  # let(:task) {}
-
-  it { expect(task.process).to eq(process)  }
-  it { expect(task.uuid).to_not be_nil }
-  it { expect(task.to_s).to match(/#{task.uuid}/) }
-  it { expect(task.options).to_not be_nil }
+  it { expect(subject.process).to eq(process)  }
+  it { expect(subject.uuid).to_not be_nil }
+  it { expect(subject.to_s).to match(/#{subject.uuid}/) }
+  it { expect(subject.options).to_not be_nil }
 
 end

--- a/spec/support/process_methods.rb
+++ b/spec/support/process_methods.rb
@@ -1,0 +1,25 @@
+module ProcessMethods
+  def enqueue
+  end
+
+  def cancel
+  end
+
+  def start
+  end
+
+  def pause
+  end
+
+  def resume
+  end
+
+  def complete
+  end
+
+  def fail(error)
+  end
+
+  def task_completed(task)
+  end
+end

--- a/spec/support/task_methods.rb
+++ b/spec/support/task_methods.rb
@@ -1,0 +1,13 @@
+module TaskMethods
+  def enqueue
+  end
+
+  def start
+  end
+
+  def complete
+  end
+
+  def fail(error)
+  end
+end

--- a/spec/support/test_instrumenter.rb
+++ b/spec/support/test_instrumenter.rb
@@ -1,5 +1,30 @@
 class TestInstrumenter
 
+  class << self
+
+    def subscribe(callback, filter=nil, &block)
+
+      # create test instrumenter instance
+      instrumenter = TestInstrumenter.new do |name, payload|
+        if filter
+          callback.call(name, payload) if name =~ filter
+        else
+          callback.call(name, payload)
+        end
+      end
+
+      # hook up this instrumenter in the context of the spec
+      # (assuming called from RSpec binding)
+      spec_binding = block.binding.eval('self')
+      spec_binding.instance_exec do
+        allow(Taskinator).to receive(:instrumenter).and_return(instrumenter)
+      end
+
+      yield
+    end
+
+  end
+
   attr_reader :callback
 
   def initialize(&block)

--- a/spec/taskinator/definition_spec.rb
+++ b/spec/taskinator/definition_spec.rb
@@ -148,8 +148,7 @@ describe Taskinator::Definition do
           expect(args.first).to eq('taskinator.process.created')
         end
 
-        # temporary subscription
-        ActiveSupport::Notifications.subscribed(instrumentation_block, /taskinator.process.created/) do
+        TestInstrumenter.subscribe(instrumentation_block, /taskinator.process.created/) do
           subject.create_process :foo
         end
       end
@@ -160,8 +159,7 @@ describe Taskinator::Definition do
           expect(args.first).to eq('taskinator.process.saved')
         end
 
-        # temporary subscription
-        ActiveSupport::Notifications.subscribed(instrumentation_block, /taskinator.process.saved/) do
+        TestInstrumenter.subscribe(instrumentation_block, /taskinator.process.saved/) do
           subject.create_process :foo
         end
       end

--- a/spec/taskinator/instrumentation_spec.rb
+++ b/spec/taskinator/instrumentation_spec.rb
@@ -52,7 +52,7 @@ describe Taskinator::Instrumentation, :redis => true do
   describe "#enqueued_payload" do
   end
 
-  describe "#started_payload" do
+  describe "#processing_payload" do
   end
 
   describe "#completed_payload" do
@@ -63,25 +63,29 @@ describe Taskinator::Instrumentation, :redis => true do
           subject.process_key,
           [:options, YAML.dump({:foo => :bar})],
           [:tasks_count, 100],
-          [:completed, 3],
-          [:cancelled, 2],
-          [:failed, 1]
+          [:tasks_processing, 1],
+          [:tasks_completed, 2],
+          [:tasks_cancelled, 3],
+          [:tasks_failed, 4]
         )
       end
 
-      expect(subject.completed_payload(:baz => :qux)).to eq({
-        :type                  => subject.class.name,
-        :process_uuid          => subject.uuid,
-        :process_options       => {:foo => :bar},
-        :uuid                  => subject.uuid,
-        :state                 => :completed,
-        :options               => subject.options,
-        :percentage_failed     => 1.0,
-        :percentage_cancelled  => 2.0,
-        :percentage_completed  => 3.0,
-        :instance              => subject,
-        :baz                   => :qux
-      })
+      expect(subject.completed_payload(:baz => :qux)).to eq(
+        OpenStruct.new({
+          :type                   => subject.class,
+          :process_uuid           => subject.uuid,
+          :process_options        => {:foo => :bar},
+          :uuid                   => subject.uuid,
+          :state                  => :completed,
+          :options                => subject.options,
+          :percentage_processing  => 1.0,
+          :percentage_completed   => 2.0,
+          :percentage_cancelled   => 3.0,
+          :percentage_failed      => 4.0,
+          :instance               => subject,
+          :baz                    => :qux
+        })
+      )
     }
   end
 

--- a/spec/taskinator/persistence_spec.rb
+++ b/spec/taskinator/persistence_spec.rb
@@ -30,16 +30,6 @@ describe Taskinator::Persistence, :redis => true do
       }
     end
 
-    describe ".state_for" do
-      before do
-        allow(subject).to receive(:base_key) { 'base_key' }
-      end
-
-      it {
-        expect(subject.state_for('uuid')).to eq(:initial)
-      }
-    end
-
     describe ".fetch" do
       before do
         allow(subject).to receive(:base_key) { 'base_key' }
@@ -320,7 +310,7 @@ describe Taskinator::Persistence, :redis => true do
       describe "#count_#{status}" do
         it {
           Taskinator.redis do |conn|
-            conn.hset(subject.process_key, status, 99)
+            conn.hset(subject.process_key, "tasks_#{status}", 99)
           end
 
           expect(subject.send(:"count_#{status}")).to eq(99)
@@ -330,7 +320,7 @@ describe Taskinator::Persistence, :redis => true do
       describe "#incr_#{status}" do
         it {
           Taskinator.redis do |conn|
-            conn.hset(subject.process_key, status, 99)
+            conn.hset(subject.process_key, "tasks_#{status}", 99)
           end
 
           subject.send(:"incr_#{status}")
@@ -345,7 +335,7 @@ describe Taskinator::Persistence, :redis => true do
             conn.hmset(
               subject.process_key,
               [:tasks_count, 100],
-              [status, 1]
+              ["tasks_#{status}", 1]
             )
           end
 

--- a/taskinator.gemspec
+++ b/taskinator.gemspec
@@ -25,7 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redis-namespace'             , '>= 1.5.2'
   spec.add_dependency 'connection_pool'             , '>= 2.2.0'
   spec.add_dependency 'json'                        , '>= 1.8.2'
-
-  # spec.add_dependency 'workflow'                    , '>= 1.3.0'  # RubyGems not up to date as of 11 Nov 2014.
-
 end


### PR DESCRIPTION
* Added `created_at` and `updated_at` to process and task as attributes.
* Improved serialization visitor to include an optional converter block for deserialization of attribute values.
* Corrections to lazy loader logic and speed improvements.
* Removed JobWorker as it's no longer necessary.
* Improvements to instrumentation.
* Removed workflow gem, and refactored process and task to implement the basics instead.
* Several bug fixes.
