### PR TITLE
Change the option? method look at the value of the key

### DIFF
--- a/lib/taskinator/definition/builder.rb
+++ b/lib/taskinator/definition/builder.rb
@@ -16,7 +16,7 @@ module Taskinator
       end
 
       def option?(key, &block)
-        yield if builder_options.key?(key) && builder_options[key]
+        yield if builder_options[key]
       end
 
       # defines a sub process of tasks which are executed sequentially


### PR DESCRIPTION
So you can now do:

```ruby
module MyProcess
  extend Taskinator::Definition

  define_process do

    option?(:some_setting) do
      task :prerequisite_step
    end

    # ...

  end

  # ...

end

process1 = MyProcess.create_process :some_setting => true
process2 = MyProcess.create_process :some_setting => false
```

This is helpful in the case where the true or false is in a variable.
