### PR TITLE
Adding queue adapter settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install taskinator
+   
 
 ## Usage
 
@@ -688,6 +689,13 @@ Taskinator.configure do |config|
     :process_queue => :default,
     :task_queue => :default
   }
+end
+```
+
+Set your queue adapter in config/initializer/taskinator.rb
+```ruby
+Taskinator.configure do |config|
+    config.queue_adapter = :sidekiq # :resque, :active_job
 end
 ```
 


### PR DESCRIPTION
It was missing this configuration which makes raise error if not using resque as default Active Job adapter