### PR TITLE
Use newer format for pipelined and multi requests in redis

### DIFF
--- a/spec/taskinator/api_spec.rb
+++ b/spec/taskinator/api_spec.rb
@@ -17,8 +17,8 @@ describe Taskinator::Api, :redis => true do
         allow_any_instance_of(Process).to receive(:fetch) {}
 
         Taskinator.redis do |conn|
-          conn.multi do
-            3.times {|i| conn.sadd(Taskinator::Persistence.processes_list_key, i) }
+          conn.multi do |transaction|
+            3.times {|i| transaction.sadd(Taskinator::Persistence.processes_list_key, i) }
           end
         end
 
@@ -34,8 +34,8 @@ describe Taskinator::Api, :redis => true do
 
       it "yields the number of processes" do
         Taskinator.redis do |conn|
-          conn.multi do
-            3.times {|i| conn.sadd(Taskinator::Persistence.processes_list_key, i) }
+          conn.multi do |transaction|
+            3.times {|i| transaction.sadd(Taskinator::Persistence.processes_list_key, i) }
           end
         end
 


### PR DESCRIPTION
The latest version of the `redis` gem has deprecation warnings for the older form of pipelined and multi requests. This patch updates calls to `#pipelined` and `#multi` to call methods on the object passed as the block parameter, rather than the connection itself.

The specs all pass, although no new specs have been added for this PR, and there shouldn't be any change to functionality.